### PR TITLE
Extend ASUS EC detection to other Crosshair VIII models

### DIFF
--- a/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
+++ b/LibreHardwareMonitorLib/Hardware/Motherboard/Identification.cs
@@ -141,7 +141,7 @@ namespace LibreHardwareMonitor.Hardware.Motherboard
                     return Model.P55_Deluxe;
                 case var _ when name.Equals("Crosshair III Formula", StringComparison.OrdinalIgnoreCase):
                     return Model.CROSSHAIR_III_FORMULA;
-                case var _ when name.Equals("ROG CROSSHAIR VIII HERO", StringComparison.OrdinalIgnoreCase):
+                case var _ when name.StartsWith("ROG CROSSHAIR VIII", StringComparison.OrdinalIgnoreCase):
                     return Model.ROG_CROSSHAIR_VIII_HERO;
                 case var _ when name.Equals("M2N-SLI DELUXE", StringComparison.OrdinalIgnoreCase):
                     return Model.M2N_SLI_Deluxe;


### PR DESCRIPTION
Tested to work on my CROSSHAIR VIII Dark Hero.
*Should* also work on the Impact, Formula and Extreme boards since they use the same sensors and thereby most likely the same EC.

Alternatively, an extra case with `name.Equals("ROG CROSSHAIR VIII DARK HERO", StringComparison.OrdinalIgnoreCase)` could be used instead.